### PR TITLE
Start laravel development server

### DIFF
--- a/nine27-pharmacy-backend/routes/web.php
+++ b/nine27-pharmacy-backend/routes/web.php
@@ -15,18 +15,3 @@ Route::get('/login', function () {
 Route::get('/register', function () {
     return response()->json(['message' => 'Please use the API endpoints for authentication']);
 })->name('register');
-
-// API routes for Nine27 Pharmacy
-Route::prefix('api')->group(function () {
-    Route::get('/health', function () {
-        return response()->json([
-            'status' => 'ok',
-            'timestamp' => now(),
-            'service' => 'Nine27 Pharmacy API'
-        ]);
-    });
-    
-    Route::get('/test', function () {
-        return response()->json(['message' => 'API is working!']);
-    });
-});


### PR DESCRIPTION
Remove duplicate `/api` routes from `routes/web.php` to prevent `QueryException` errors.

The `/api/health` endpoint was being processed by the `web` middleware group due to a duplicate route in `routes/web.php`, which caused a `QueryException` when trying to access the `sessions` table for non-existent database sessions. Removing this duplication ensures API routes are handled exclusively by `routes/api.php` under the API middleware, which does not rely on database sessions.

---
<a href="https://cursor.com/background-agent?bcId=bc-431b8401-12dc-43fa-b2f2-92cf2050e67f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-431b8401-12dc-43fa-b2f2-92cf2050e67f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

